### PR TITLE
らこらこポイント

### DIFF
--- a/lacolaco_plugin.rb
+++ b/lacolaco_plugin.rb
@@ -12,7 +12,8 @@ Plugin.create(:lacolaco_plugin) do
         laco_orudew m[:created]
       end
       if !(m[:created] < launched_time) &&
-          !m.retweet?() &&
+          !m.retweet? &&
+          !m.user.is_me? &&
           m.message.to_s.include?("らこらこらこ")
         get_laco_point
         Plugin.call(:lacolaco, true)

--- a/lacolaco_plugin.rb
+++ b/lacolaco_plugin.rb
@@ -3,14 +3,20 @@
 Plugin.create(:lacolaco_plugin) do
 
   launched_time = Time.now
+  UserConfig[:laco_point] ||= 0
+  UserConfig[:laco_require_points] ||= 5
 
   on_appear do |ms|
     ms.each do |m|
+      if m.user[:id] == 498602690 && laco_oruka?
+        laco_orudew m[:created]
+      end
       if m[:created] < launched_time
         false
       elsif m.retweet?()
         false
       elsif m.message.to_s.include?("らこらこらこ")
+        get_laco_point
         Plugin.call(:lacolaco, true)
         if m.retweet?
           if m.retweet_source.user.is_me? == false
@@ -45,19 +51,42 @@ Plugin.create(:lacolaco_plugin) do
   end
 
   on_lacolaco do |passive|
-    unless passive && rand(3) != 0
-      
-    else
-      Service.primary.update(:message => "らこらこらこ〜ｗ").trap{
-      unless passive
-        activity :system, "失敗しました"
+    if !passive || rand(3) == 0
+      if UserConfig[:laco_point] < UserConfig[:laco_require_points]
+        activity :system, "らこらこポイントが足りないよ (#{UserConfig[:laco_point]} pts)"
+      else
+        Service.primary.update(:message => "らこらこらこ〜ｗ").next {
+          UserConfig[:laco_point] -= UserConfig[:laco_require_points]
+        }.trap {
+          unless passive
+            activity :system, "失敗しました"
+          end
+        }
       end
-    }
     end
   end
 
   settings "らこらこ" do
     boolean "えんくんあんふぁぼ機能", :laco_enkun
   end
-  
+
+  # らこらこ〜おるか？ｗ
+  def laco_oruka?
+    defined?(@last_laco_time) && @last_laco_time > (Time.now - 600)
+  end
+
+  # らこらこがおる時にこれを呼ぶ
+  def laco_orudew(time)
+    @last_laco_time = time
+  end
+
+  # らこらこポイントを獲得。 laco_oruka? が真を返す場合はポイント二倍セール。
+  def get_laco_point(given=1)
+    if laco_oruka?
+      UserConfig[:laco_point] += given * 2
+    else
+      UserConfig[:laco_point] += given
+    end
+  end
+
 end

--- a/lacolaco_plugin.rb
+++ b/lacolaco_plugin.rb
@@ -11,21 +11,17 @@ Plugin.create(:lacolaco_plugin) do
       if m.user[:id] == 498602690 && laco_oruka?
         laco_orudew m[:created]
       end
-      if m[:created] < launched_time
-        false
-      elsif m.retweet?()
-        false
-      elsif m.message.to_s.include?("らこらこらこ")
+      if !(m[:created] < launched_time) &&
+          !m.retweet?() &&
+          m.message.to_s.include?("らこらこらこ")
         get_laco_point
         Plugin.call(:lacolaco, true)
         if m.retweet?
           if m.retweet_source.user.is_me? == false
             m.favorite(true)
           end
-        else
-          if m.user.is_me? == false
-            m.favorite(true)
-          end
+        elsif m.user.is_me? == false
+          m.favorite(true)
         end
       end
     end


### PR DESCRIPTION
らこらこの頻度を調整するために、らこらこポイントを実装しました。以下のような仕様になっています。
- 増加条件 TLで、自分以外が「らこらこらこ」と言うたび、1pt増加します。
- らこらこコスト 自分が、らこらこプラグインによって「らこらこらこ〜ｗ」というツイートに成功した場合、5pt消費します。ショートカットキーで呼び出しても、ポイントが足りなければらこらこできません。
- ポイント2倍セール @laco0416 のツイートを受信してから10分の間は、入手ポイントが倍になります。

これによって以下の効果が期待できると思います。
- らこらこしすぎない…以前の実装では、3らこに1回らこる可能性がありましたが、5ポイントないと抽選されないので、頻度が減ると思います。
- おる時にらこる…らこらこがいないとポイントが溜まりづらいため、バイトや学校から帰ってきたあと、エゴサーチタブが死ぬ可能性が低くなります。
- ゲーミフィケーションによるらこらこの助長…ておくれになるかもしれない。ただし、らこらこポイントをUI上から確認できないようにしたので、案外大丈夫かもしれない。

この変更によって、らこらこしない条件しか追加していないのでらこらこは減ります。しかし、より最適なタイミングでらこらこできるようになるのではないでしょうか。コストは適当に変更してもいいかもしれません。3ptでは少ないと感じ、5ptにしました。
