### PR TITLE
Message#message を使わない

### DIFF
--- a/lacolaco_plugin.rb
+++ b/lacolaco_plugin.rb
@@ -15,7 +15,7 @@ Plugin.create(:lacolaco_plugin) do
       if !(m[:created] < launched_time) &&
           !m.retweet? &&
           !m.user.is_me? &&
-          m.message.to_s.include?("らこらこらこ")
+          m.to_s.include?("らこらこらこ")
         get_laco_point
         Plugin.call(:lacolaco, true)
         if m.retweet?


### PR DESCRIPTION
mikutter 3.4から、Message#messageがdeprecatedになる予定なので、警告が出てしまいます。このメソッドはselfを返すだけなので、単に使わないようにしました。

この変更はmikutter 3.3以前に影響が出ることはありません。
